### PR TITLE
Update version of giter8 plugin 0.3.{1 --> 2}

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.11.2

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("net.databinder" %% "giter8-plugin" % "0.3.1")
+addSbtPlugin("net.databinder" %% "giter8-plugin" % "0.3.2")


### PR DESCRIPTION
Fixed the following error in my environment:

```
$ cd android-app.g8
$ sbt
...
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  ::          UNRESOLVED DEPENDENCIES         ::
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  :: net.databinder#giter8-plugin;0.3.2: not found
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]
[warn]  Note: Some unresolved dependencies have extra attributes.  Check that these dependencies exist with the requested attributes.
[warn]          net.databinder:giter8-plugin:0.3.2 (sbtVersion=0.11.3, scalaVersion=2.9.1)
```
